### PR TITLE
openssl: Xcode modernization + armv6 support

### DIFF
--- a/ports/security/openssl/openssl.xcodeproj/project.pbxproj
+++ b/ports/security/openssl/openssl.xcodeproj/project.pbxproj
@@ -7110,6 +7110,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				"ARCHS[sdk=iphoneos*]" = (
+					armv7,
+					armv6,
+				);
+				"ARCHS[sdk=iphonesimulator*]" = i386;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_VERSION = com.apple.compilers.llvmgcc42;
@@ -7140,6 +7145,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				"ARCHS[sdk=iphoneos*]" = (
+					armv7,
+					armv6,
+				);
+				"ARCHS[sdk=iphonesimulator*]" = i386;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;

--- a/ports/security/openssl/openssl.xcodeproj/project.pbxproj
+++ b/ports/security/openssl/openssl.xcodeproj/project.pbxproj
@@ -7109,10 +7109,7 @@
 		1DEB922308733DC00010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = (
-					"$(ARCHS_STANDARD_32_BIT)",
-					armv6,
-				);
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_VERSION = com.apple.compilers.llvmgcc42;
@@ -7135,16 +7132,14 @@
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				VALID_ARCHS = "i386 armv6 armv7";
 			};
 			name = Debug;
 		};
 		1DEB922408733DC00010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = (
-					"$(ARCHS_STANDARD_32_BIT)",
-					armv6,
-				);
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -7166,6 +7161,7 @@
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				VALID_ARCHS = "i386 armv6 armv7";
 			};
 			name = Release;
 		};

--- a/ports/security/openssl/openssl.xcodeproj/project.pbxproj
+++ b/ports/security/openssl/openssl.xcodeproj/project.pbxproj
@@ -7109,10 +7109,9 @@
 		1DEB922308733DC00010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
-				"ARCHS[sdk=iphoneos*]" = (
-					armv7,
+				ARCHS = (
 					armv6,
+					armv7,
 				);
 				"ARCHS[sdk=iphonesimulator*]" = i386;
 				GCC_C_LANGUAGE_STANDARD = c99;
@@ -7144,10 +7143,9 @@
 		1DEB922408733DC00010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
-				"ARCHS[sdk=iphoneos*]" = (
-					armv7,
+				ARCHS = (
 					armv6,
+					armv7,
 				);
 				"ARCHS[sdk=iphonesimulator*]" = i386;
 				GCC_C_LANGUAGE_STANDARD = c99;

--- a/ports/security/scrypt/.gitignore
+++ b/ports/security/scrypt/.gitignore
@@ -1,0 +1,4 @@
+/scrypt
+/scrypt-1.1.6
+/scrypt-1.1.6.tgz
+/scrypt-1.1.6.tgz.md5

--- a/ports/security/scrypt/Makefile
+++ b/ports/security/scrypt/Makefile
@@ -1,0 +1,75 @@
+#
+#  iOS Ports Library
+#  Copyright (C) 2010 Bindle Binaries
+#  All rights reserved.
+#
+#  @BINDLE_BINARIES_BSD_LICENSE_START@
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Bindle Binaries nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BINDLE BINARIES BE LIABLE FOR
+#  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+#  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+#  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+#  SUCH DAMAGE.
+#
+#  @BINDLE_BINARIES_BSD_LICENSE_END@
+#
+#  Makefile -- automate downloading of package files
+#
+
+# Package Information
+PACKAGE_NAME				= scrypt key derivation library
+PACKAGE_TARNAME				= scrypt
+PACKAGE_VERSION				= 1.1.6
+PACKAGE_DIR				= $(PACKAGE_TARNAME)-$(PACKAGE_VERSION)
+PACKAGE_FILEEXE				= tgz
+PACKAGE_FILE				= $(PACKAGE_DIR).$(PACKAGE_FILEEXE)
+PACKAGE_MD5				= $(PACKAGE_FILE).md5
+PACKAGE_URL				= http://www.tarsnap.com/scrypt/$(PACKAGE_FILE)
+PACKAGE_WEBSITE				= http://www.tarsnap.com/scrypt.html
+PACKAGE_LICENSE_FILE			= build-aux/LICENSE
+
+SRCROOTDIR = ../../..
+include $(SRCROOTDIR)/build-aux/Makefile-package
+
+PKGHEADERS = scrypt/config.h
+
+$(PKGHEADERS): $(PACKAGE_TARNAME)
+	FILE="build-aux/`basename ${@}`"; cp $${FILE} ${@};
+
+scrypt/patched_for_xcode: $(PKGHEADERS)
+	patch -N -p0 -i build-aux/scrypt-1.1.6.patch || exit 0
+	touch scrypt/patched_for_xcode
+
+../../../include/scrypt/scryptenc.h: $(PKGHEADERS)
+	@mkdir -p ../../../include/scrypt
+	cp scrypt/lib/*/*.h ../../../include/scrypt/
+
+extra-prep: scrypt/patched_for_xcode $(PKGHEADERS) ../../../include/scrypt/scryptenc.h
+
+clean-local:
+	/bin/rm -Rf include
+	/bin/rm -Rf ../../../include/scrypt
+
+distclean-local:
+	/bin/rm -Rf build
+
+# end of Makefile

--- a/ports/security/scrypt/build-aux/LICENSE
+++ b/ports/security/scrypt/build-aux/LICENSE
@@ -1,0 +1,75 @@
+
+
+LICENSE ISSUES
+==============
+
+The OpenSSL toolkit stays under a dual license, i.e. both the conditions of the OpenSSL License and the original SSLeay license apply to the toolkit.  See below for the actual license texts. Actually both licenses are BSD-style Open Source licenses. In case of any license issues related to OpenSSL please contact openssl-core@openssl.org.
+
+OpenSSL License
+---------------
+
+====================================================================
+Copyright (c) 1998-2008 The OpenSSL Project.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. All advertising materials mentioning features or use of this software must display the following acknowledgment:
+   "This product includes software developed
+    by the OpenSSL Project for use in the OpenSSL
+    Toolkit. (http://www.openssl.org/)"
+
+4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to endorse or promote products derived from this software without prior written permission. For written permission, please contact openssl-core@openssl.org.
+
+5. Products derived from this software may not be called "OpenSSL" nor may "OpenSSL" appear in their names without prior written permission of the OpenSSL Project.
+
+6. Redistributions of any form whatsoever must retain the following acknowledgment:
+   "This product includes software developed
+   by the OpenSSL Project for use in the OpenSSL
+   Toolkit (http://www.openssl.org/)"
+
+THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+====================================================================
+
+This product includes cryptographic software written by Eric Young (eay@cryptsoft.com).  This product includes software written by Tim Hudson (tjh@cryptsoft.com).
+
+
+Original SSLeay License
+-----------------------
+
+Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+All rights reserved.
+
+This package is an SSL implementation written
+by Eric Young (eay@cryptsoft.com).
+The implementation was written so as to conform with Netscapes SSL.
+
+This library is free for commercial and non-commercial use as long as the following conditions are aheared to.  The following conditions apply to all code found in this distribution, be it the RC4, RSA, lhash, DES, etc., code; not just the SSL code.  The SSL documentation included with this distribution is covered by the same copyright terms except that the holder is Tim Hudson (tjh@cryptsoft.com).
+
+Copyright remains Eric Young's, and as such any Copyright notices in the code are not to be removed.  If this package is used in a product, Eric Young should be given attribution as the author of the parts of the library used.  This can be in the form of a textual message at program startup or in documentation (online or textual) provided with the package.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. All advertising materials mentioning features or use of this software must display the following acknowledgement:
+   "This product includes cryptographic
+    software written by Eric Young
+   (eay@cryptsoft.com)"
+   The word 'cryptographic' can be left out if the rouines from the library being used are not cryptographic related :-).
+
+4. If you include any Windows specific code (or a derivative thereof) from the apps directory (application code) you must include an acknowledgement:
+   "This product includes software
+    written by Tim Hudson (tjh@cryptsoft.com)"
+
+THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The licence and distribution terms for any publically available version or derivative of this code cannot be changed.  i.e. this code cannot simply be copied and put under another distribution licence [including the GNU Public Licence.]
+
+

--- a/ports/security/scrypt/build-aux/config.h
+++ b/ports/security/scrypt/build-aux/config.h
@@ -1,0 +1,99 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have the `clock_gettime' function. */
+/* #undef HAVE_CLOCK_GETTIME */
+
+/* Define to 1 if you have the declaration of `be64enc', and to 0 if you
+   don't. */
+#define HAVE_DECL_BE64ENC 0
+
+/* Define to 1 if you have the <err.h> header file. */
+#define HAVE_ERR_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the `rt' library (-lrt). */
+/* #undef HAVE_LIBRT */
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `posix_memalign' function. */
+#define HAVE_POSIX_MEMALIGN 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if the system has the type `struct sysinfo'. */
+/* #undef HAVE_STRUCT_SYSINFO */
+
+/* Define to 1 if `mem_unit' is member of `struct sysinfo'. */
+/* #undef HAVE_STRUCT_SYSINFO_MEM_UNIT */
+
+/* Define to 1 if `totalram' is member of `struct sysinfo'. */
+/* #undef HAVE_STRUCT_SYSINFO_TOTALRAM */
+
+/* Define to 1 if the OS has a hw.usermem sysctl */
+#define HAVE_SYSCTL_HW_USERMEM 1
+
+/* Define to 1 if you have the `sysinfo' function. */
+/* #undef HAVE_SYSINFO */
+
+/* Define to 1 if you have the <sys/endian.h> header file. */
+/* #undef HAVE_SYS_ENDIAN_H */
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#define HAVE_SYS_PARAM_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/sysinfo.h> header file. */
+/* #undef HAVE_SYS_SYSINFO_H */
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Name of package */
+#define PACKAGE "scrypt"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "scrypt"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "scrypt 1.1.6"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "scrypt"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.1.6"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "1.1.6"
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+/* #undef _FILE_OFFSET_BITS */
+
+/* Define for large files, on AIX-style hosts. */
+/* #undef _LARGE_FILES */

--- a/ports/security/scrypt/build-aux/configure-wrapper.log
+++ b/ports/security/scrypt/build-aux/configure-wrapper.log
@@ -1,0 +1,210 @@
+Operating system: i686-apple-darwinDarwin Kernel Version 10.4.0: Fri Apr 23 18:28:53 PDT 2010; root:xnu-1504.7.4~1/RELEASE_I386
+WARNING! If you wish to build 64-bit library, then you have to
+         invoke './Configure darwin64-x86_64-cc' *manually*.
+         You have about 5 seconds to press Ctrl-C to abort.
+Configuring for darwin-i386-cc
+Configuring for darwin-i386-cc
+    no-asm          [option]   OPENSSL_NO_ASM
+    no-dso          [option]  
+    no-gmp          [default]  OPENSSL_NO_GMP (skip dir)
+    no-jpake        [experimental] OPENSSL_NO_JPAKE (skip dir)
+    no-krb5         [krb5-flavor not specified] OPENSSL_NO_KRB5
+    no-md2          [default]  OPENSSL_NO_MD2 (skip dir)
+    no-rc5          [default]  OPENSSL_NO_RC5 (skip dir)
+    no-rfc3779      [default]  OPENSSL_NO_RFC3779 (skip dir)
+    no-shared       [option]  
+    no-store        [experimental] OPENSSL_NO_STORE (skip dir)
+    no-threads      [option]  
+    no-zlib         [option]  
+    no-zlib-dynamic [default] 
+IsMK1MF=0
+CC            =cc
+CFLAG         =-arch i386 -O3 -fomit-frame-pointer -DL_ENDIAN
+EX_LIBS       =
+CPUID_OBJ     =mem_clr.o
+BN_ASM        =bn_asm.o
+DES_ENC       =des_enc.o fcrypt_b.o
+AES_ENC       =aes_core.o aes_cbc.o
+BF_ENC        =bf_enc.o
+CAST_ENC      =c_enc.o
+RC4_ENC       =rc4_enc.o rc4_skey.o
+RC5_ENC       =rc5_enc.o
+MD5_OBJ_ASM   =
+SHA1_OBJ_ASM  =
+RMD160_OBJ_ASM=
+CMLL_ENC=     =camellia.o cmll_misc.o cmll_cbc.o
+PROCESSOR     =
+RANLIB        =/usr/bin/ranlib
+ARFLAGS       =
+PERL          =/opt/local/bin/perl5
+THIRTY_TWO_BIT mode
+DES_UNROLL used
+BN_LLONG mode
+RC4_CHUNK is unsigned long
+BF_PTR used
+e_os2.h => include/openssl/e_os2.h
+making links in crypto...
+crypto.h => ../include/openssl/crypto.h
+opensslv.h => ../include/openssl/opensslv.h
+opensslconf.h => ../include/openssl/opensslconf.h
+ebcdic.h => ../include/openssl/ebcdic.h
+symhacks.h => ../include/openssl/symhacks.h
+ossl_typ.h => ../include/openssl/ossl_typ.h
+making links in crypto/objects...
+objects.h => ../../include/openssl/objects.h
+obj_mac.h => ../../include/openssl/obj_mac.h
+making links in crypto/md4...
+md4.h => ../../include/openssl/md4.h
+md4test.c => ../../test/md4test.c
+md4.c => ../../apps/md4.c
+making links in crypto/md5...
+md5.h => ../../include/openssl/md5.h
+md5test.c => ../../test/md5test.c
+making links in crypto/sha...
+sha.h => ../../include/openssl/sha.h
+shatest.c => ../../test/shatest.c
+sha1test.c => ../../test/sha1test.c
+sha256t.c => ../../test/sha256t.c
+sha512t.c => ../../test/sha512t.c
+making links in crypto/mdc2...
+mdc2.h => ../../include/openssl/mdc2.h
+mdc2test.c => ../../test/mdc2test.c
+making links in crypto/hmac...
+hmac.h => ../../include/openssl/hmac.h
+hmactest.c => ../../test/hmactest.c
+making links in crypto/ripemd...
+ripemd.h => ../../include/openssl/ripemd.h
+rmdtest.c => ../../test/rmdtest.c
+making links in crypto/whrlpool...
+whrlpool.h => ../../include/openssl/whrlpool.h
+wp_test.c => ../../test/wp_test.c
+making links in crypto/des...
+des.h => ../../include/openssl/des.h
+des_old.h => ../../include/openssl/des_old.h
+destest.c => ../../test/destest.c
+making links in crypto/aes...
+aes.h => ../../include/openssl/aes.h
+making links in crypto/rc2...
+rc2.h => ../../include/openssl/rc2.h
+rc2test.c => ../../test/rc2test.c
+making links in crypto/rc4...
+rc4.h => ../../include/openssl/rc4.h
+rc4test.c => ../../test/rc4test.c
+making links in crypto/idea...
+idea.h => ../../include/openssl/idea.h
+ideatest.c => ../../test/ideatest.c
+making links in crypto/bf...
+blowfish.h => ../../include/openssl/blowfish.h
+bftest.c => ../../test/bftest.c
+making links in crypto/cast...
+cast.h => ../../include/openssl/cast.h
+casttest.c => ../../test/casttest.c
+making links in crypto/camellia...
+camellia.h => ../../include/openssl/camellia.h
+making links in crypto/seed...
+seed.h => ../../include/openssl/seed.h
+making links in crypto/modes...
+modes.h => ../../include/openssl/modes.h
+making links in crypto/bn...
+bn.h => ../../include/openssl/bn.h
+bntest.c => ../../test/bntest.c
+exptest.c => ../../test/exptest.c
+making links in crypto/ec...
+ec.h => ../../include/openssl/ec.h
+ectest.c => ../../test/ectest.c
+making links in crypto/rsa...
+rsa.h => ../../include/openssl/rsa.h
+rsa_test.c => ../../test/rsa_test.c
+making links in crypto/dsa...
+dsa.h => ../../include/openssl/dsa.h
+dsatest.c => ../../test/dsatest.c
+making links in crypto/ecdsa...
+ecdsa.h => ../../include/openssl/ecdsa.h
+ecdsatest.c => ../../test/ecdsatest.c
+making links in crypto/dh...
+dh.h => ../../include/openssl/dh.h
+dhtest.c => ../../test/dhtest.c
+making links in crypto/ecdh...
+ecdh.h => ../../include/openssl/ecdh.h
+ecdhtest.c => ../../test/ecdhtest.c
+making links in crypto/dso...
+dso.h => ../../include/openssl/dso.h
+making links in crypto/engine...
+engine.h => ../../include/openssl/engine.h
+enginetest.c => ../../test/enginetest.c
+making links in crypto/buffer...
+buffer.h => ../../include/openssl/buffer.h
+making links in crypto/bio...
+bio.h => ../../include/openssl/bio.h
+making links in crypto/stack...
+stack.h => ../../include/openssl/stack.h
+safestack.h => ../../include/openssl/safestack.h
+making links in crypto/lhash...
+lhash.h => ../../include/openssl/lhash.h
+making links in crypto/rand...
+rand.h => ../../include/openssl/rand.h
+randtest.c => ../../test/randtest.c
+making links in crypto/err...
+err.h => ../../include/openssl/err.h
+making links in crypto/evp...
+evp.h => ../../include/openssl/evp.h
+evp_test.c => ../../test/evp_test.c
+cp evptests.txt ../../test
+making links in crypto/asn1...
+asn1.h => ../../include/openssl/asn1.h
+asn1_mac.h => ../../include/openssl/asn1_mac.h
+asn1t.h => ../../include/openssl/asn1t.h
+making links in crypto/pem...
+pem.h => ../../include/openssl/pem.h
+pem2.h => ../../include/openssl/pem2.h
+making links in crypto/x509...
+x509.h => ../../include/openssl/x509.h
+x509_vfy.h => ../../include/openssl/x509_vfy.h
+making links in crypto/x509v3...
+x509v3.h => ../../include/openssl/x509v3.h
+making links in crypto/conf...
+conf.h => ../../include/openssl/conf.h
+conf_api.h => ../../include/openssl/conf_api.h
+making links in crypto/txt_db...
+txt_db.h => ../../include/openssl/txt_db.h
+making links in crypto/pkcs7...
+pkcs7.h => ../../include/openssl/pkcs7.h
+making links in crypto/pkcs12...
+pkcs12.h => ../../include/openssl/pkcs12.h
+making links in crypto/comp...
+comp.h => ../../include/openssl/comp.h
+making links in crypto/ocsp...
+ocsp.h => ../../include/openssl/ocsp.h
+making links in crypto/ui...
+ui.h => ../../include/openssl/ui.h
+ui_compat.h => ../../include/openssl/ui_compat.h
+making links in crypto/krb5...
+krb5_asn.h => ../../include/openssl/krb5_asn.h
+making links in crypto/cms...
+cms.h => ../../include/openssl/cms.h
+making links in crypto/pqueue...
+pqueue.h => ../../include/openssl/pqueue.h
+making links in crypto/ts...
+ts.h => ../../include/openssl/ts.h
+making links in ssl...
+ssl.h => ../include/openssl/ssl.h
+ssl2.h => ../include/openssl/ssl2.h
+ssl3.h => ../include/openssl/ssl3.h
+ssl23.h => ../include/openssl/ssl23.h
+tls1.h => ../include/openssl/tls1.h
+dtls1.h => ../include/openssl/dtls1.h
+kssl.h => ../include/openssl/kssl.h
+ssltest.c => ../test/ssltest.c
+making links in engines...
+making links in engines/ccgost...
+make[2]: Nothing to be done for `links'.
+making links in apps...
+make[1]: Nothing to be done for `links'.
+making links in test...
+make[1]: Nothing to be done for `links'.
+making links in tools...
+make[1]: Nothing to be done for `links'.
+generating dummy tests (if needed)...
+make[1]: Nothing to be done for `generate'.
+
+Configured for darwin-i386-cc.

--- a/ports/security/scrypt/build-aux/configure-wrapper.sh
+++ b/ports/security/scrypt/build-aux/configure-wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+./configure \
+   "$@"
+

--- a/ports/security/scrypt/build-aux/scrypt-1.1.6.patch
+++ b/ports/security/scrypt/build-aux/scrypt-1.1.6.patch
@@ -1,0 +1,28 @@
+--- scrypt/lib/scryptenc/scryptenc.h~	2010-01-16 21:48:20.000000000 +0100
++++ scrypt/lib/scryptenc/scryptenc.h	2012-02-10 17:23:18.000000000 +0100
+@@ -72,6 +72,9 @@
+  * 13	error reading input file
+  */
+ 
++int pickparams(size_t, double, double,
++    int *, uint32_t *, uint32_t *);
++
+ /**
+  * scryptenc_buf(inbuf, inbuflen, outbuf, passwd, passwdlen,
+  *     maxmem, maxmemfrac, maxtime):
+--- scrypt/lib/scryptenc/scryptenc.c~	2010-01-16 21:48:20.000000000 +0100
++++ scrypt/lib/scryptenc/scryptenc.c	2012-02-10 17:23:18.000000000 +0100
+@@ -48,12 +48,10 @@
+ 
+ #define ENCBLOCK 65536
+ 
+-static int pickparams(size_t, double, double,
+-    int *, uint32_t *, uint32_t *);
+ static int checkparams(size_t, double, double, int, uint32_t, uint32_t);
+ static int getsalt(uint8_t[32]);
+ 
+-static int
++int
+ pickparams(size_t maxmem, double maxmemfrac, double maxtime,
+     int * logN, uint32_t * r, uint32_t * p)
+ {

--- a/ports/security/scrypt/build-aux/scrypt-1.1.6.tgz.md5
+++ b/ports/security/scrypt/build-aux/scrypt-1.1.6.tgz.md5
@@ -1,0 +1,1 @@
+MD5 (scrypt-1.1.6.tgz) = a35523cd497f7283635ce881db39c2e2

--- a/ports/security/scrypt/scrypt.xcodeproj/project.pbxproj
+++ b/ports/security/scrypt/scrypt.xcodeproj/project.pbxproj
@@ -1,0 +1,766 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		A0511DCE127788A100DE46C4 /* scrypt */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = A0511DEA127788C900DE46C4 /* Build configuration list for PBXAggregateTarget "scrypt" */;
+			buildPhases = (
+			);
+			dependencies = (
+				DA67FE5F14E4836300DB7CC9 /* PBXTargetDependency */,
+				A0511DD2127788A800DE46C4 /* PBXTargetDependency */,
+				A0511DD4127788A800DE46C4 /* PBXTargetDependency */,
+			);
+			name = scrypt;
+			productName = OpenSSL;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		DA1A140614E48A7600BCFFBE /* libcrypto.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA1A13F214E487D900BCFFBE /* libcrypto.a */; };
+		DA1A142514E4914800BCFFBE /* libutil.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA67FE5D14E4834300DB7CC9 /* libutil.a */; };
+		DA1A142614E4914E00BCFFBE /* libutil.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA67FE5D14E4834300DB7CC9 /* libutil.a */; };
+		DA67FE8E14E484A900DB7CC9 /* crypto_aesctr.c in Sources */ = {isa = PBXBuildFile; fileRef = DA67FE7314E4845900DB7CC9 /* crypto_aesctr.c */; };
+		DA67FE8F14E484B100DB7CC9 /* crypto_scrypt-nosse.c in Sources */ = {isa = PBXBuildFile; fileRef = DA67FE7514E4845900DB7CC9 /* crypto_scrypt-nosse.c */; };
+		DA67FE9014E484B100DB7CC9 /* crypto_scrypt-ref.c in Sources */ = {isa = PBXBuildFile; fileRef = DA67FE7614E4845900DB7CC9 /* crypto_scrypt-ref.c */; };
+		DA67FE9214E484B100DB7CC9 /* sha256.c in Sources */ = {isa = PBXBuildFile; fileRef = DA67FE7914E4845900DB7CC9 /* sha256.c */; };
+		DA67FE9314E484BB00DB7CC9 /* scryptenc.c in Sources */ = {isa = PBXBuildFile; fileRef = DA67FE7D14E4845900DB7CC9 /* scryptenc.c */; };
+		DA67FE9414E484BB00DB7CC9 /* scryptenc_cpuperf.c in Sources */ = {isa = PBXBuildFile; fileRef = DA67FE7F14E4845900DB7CC9 /* scryptenc_cpuperf.c */; };
+		DA67FE9514E484C200DB7CC9 /* memlimit.c in Sources */ = {isa = PBXBuildFile; fileRef = DA67FE8214E4845900DB7CC9 /* memlimit.c */; };
+		DA67FE9614E484C200DB7CC9 /* readpass.c in Sources */ = {isa = PBXBuildFile; fileRef = DA67FE8414E4845900DB7CC9 /* readpass.c */; };
+		DA67FE9714E484C200DB7CC9 /* warn.c in Sources */ = {isa = PBXBuildFile; fileRef = DA67FE8714E4845900DB7CC9 /* warn.c */; };
+		DA8251C514E5CDF7008EBC5A /* libscryptcrypto.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A0511C5A127770FD00DE46C4 /* libscryptcrypto.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A0511DD1127788A800DE46C4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D2AAC07D0554694100DB518D;
+			remoteInfo = ssl;
+		};
+		A0511DD3127788A800DE46C4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A0511C51127770FD00DE46C4;
+			remoteInfo = crypto;
+		};
+		A0511DF0127788F600DE46C4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A0511DED127788EC00DE46C4;
+			remoteInfo = Makefile;
+		};
+		A0511DF2127788FD00DE46C4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A0511DED127788EC00DE46C4;
+			remoteInfo = Makefile;
+		};
+		DA1A13EF14E487D900BCFFBE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA1A13E314E487D800BCFFBE /* openssl.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D2AAC07E0554694100DB518D;
+			remoteInfo = ssl;
+		};
+		DA1A13F114E487D900BCFFBE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA1A13E314E487D800BCFFBE /* openssl.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A0511C5A127770FD00DE46C4;
+			remoteInfo = crypto;
+		};
+		DA1A13F314E487D900BCFFBE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA1A13E314E487D800BCFFBE /* openssl.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A0511DFF1277895300DE46C4;
+			remoteInfo = test;
+		};
+		DA67FE2A14E4834300DB7CC9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A0511DED127788EC00DE46C4;
+			remoteInfo = Makefile;
+		};
+		DA67FE5E14E4836300DB7CC9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA67FE2814E4834300DB7CC9;
+			remoteInfo = util;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A0511321127769BB00DE46C4 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 8; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; tabWidth = 8; };
+		A0511C5A127770FD00DE46C4 /* libscryptcrypto.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libscryptcrypto.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A0511E2B127789E000DE46C4 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		A0511E2D127789E900DE46C4 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		A05123771278ACDE00DE46C4 /* README */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
+		AACBBE490F95108600F1A2B1 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		D2AAC07E0554694100DB518D /* libscryptenc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libscryptenc.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA1A13E314E487D800BCFFBE /* openssl.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = openssl.xcodeproj; path = ../openssl/openssl.xcodeproj; sourceTree = "<group>"; };
+		DA1A140714E48E1600BCFFBE /* config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
+		DA1A141614E48E9F00BCFFBE /* config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
+		DA67FE5D14E4834300DB7CC9 /* libutil.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libutil.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA67FE6014E483BD00DB7CC9 /* configure-wrapper.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "configure-wrapper.log"; sourceTree = "<group>"; };
+		DA67FE6114E483BD00DB7CC9 /* configure-wrapper.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "configure-wrapper.sh"; sourceTree = "<group>"; };
+		DA67FE6214E483BD00DB7CC9 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		DA67FE6314E483BD00DB7CC9 /* scrypt-1.1.6.patch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "scrypt-1.1.6.patch"; sourceTree = "<group>"; };
+		DA67FE6414E483BD00DB7CC9 /* scrypt-1.1.6.tgz.md5 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "scrypt-1.1.6.tgz.md5"; sourceTree = "<group>"; };
+		DA67FE6B14E4845900DB7CC9 /* depcomp */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = depcomp; sourceTree = "<group>"; };
+		DA67FE6C14E4845900DB7CC9 /* install-sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "install-sh"; sourceTree = "<group>"; };
+		DA67FE6D14E4845900DB7CC9 /* missing */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = missing; sourceTree = "<group>"; };
+		DA67FE6E14E4845900DB7CC9 /* config.h.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = config.h.in; sourceTree = "<group>"; };
+		DA67FE6F14E4845900DB7CC9 /* configure */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = configure; sourceTree = "<group>"; };
+		DA67FE7014E4845900DB7CC9 /* FORMAT */ = {isa = PBXFileReference; lastKnownFileType = text; path = FORMAT; sourceTree = "<group>"; };
+		DA67FE7314E4845900DB7CC9 /* crypto_aesctr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = crypto_aesctr.c; sourceTree = "<group>"; };
+		DA67FE7414E4845900DB7CC9 /* crypto_aesctr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = crypto_aesctr.h; sourceTree = "<group>"; };
+		DA67FE7514E4845900DB7CC9 /* crypto_scrypt-nosse.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "crypto_scrypt-nosse.c"; sourceTree = "<group>"; };
+		DA67FE7614E4845900DB7CC9 /* crypto_scrypt-ref.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "crypto_scrypt-ref.c"; sourceTree = "<group>"; };
+		DA67FE7814E4845900DB7CC9 /* crypto_scrypt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = crypto_scrypt.h; sourceTree = "<group>"; };
+		DA67FE7914E4845900DB7CC9 /* sha256.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sha256.c; sourceTree = "<group>"; };
+		DA67FE7A14E4845900DB7CC9 /* sha256.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sha256.h; sourceTree = "<group>"; };
+		DA67FE7B14E4845900DB7CC9 /* README */ = {isa = PBXFileReference; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
+		DA67FE7D14E4845900DB7CC9 /* scryptenc.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = scryptenc.c; sourceTree = "<group>"; };
+		DA67FE7E14E4845900DB7CC9 /* scryptenc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = scryptenc.h; sourceTree = "<group>"; };
+		DA67FE7F14E4845900DB7CC9 /* scryptenc_cpuperf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = scryptenc_cpuperf.c; sourceTree = "<group>"; };
+		DA67FE8014E4845900DB7CC9 /* scryptenc_cpuperf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = scryptenc_cpuperf.h; sourceTree = "<group>"; };
+		DA67FE8214E4845900DB7CC9 /* memlimit.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = memlimit.c; sourceTree = "<group>"; };
+		DA67FE8314E4845900DB7CC9 /* memlimit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = memlimit.h; sourceTree = "<group>"; };
+		DA67FE8414E4845900DB7CC9 /* readpass.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = readpass.c; sourceTree = "<group>"; };
+		DA67FE8514E4845900DB7CC9 /* readpass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = readpass.h; sourceTree = "<group>"; };
+		DA67FE8614E4845900DB7CC9 /* sysendian.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sysendian.h; sourceTree = "<group>"; };
+		DA67FE8714E4845900DB7CC9 /* warn.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = warn.c; sourceTree = "<group>"; };
+		DA67FE8814E4845900DB7CC9 /* warn.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = warn.h; sourceTree = "<group>"; };
+		DA67FE8914E4845900DB7CC9 /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		DA67FE8A14E4845900DB7CC9 /* Makefile.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.in; sourceTree = "<group>"; };
+		DA67FE8B14E4845900DB7CC9 /* patched_for_xcode */ = {isa = PBXFileReference; lastKnownFileType = text; path = patched_for_xcode; sourceTree = "<group>"; };
+		DA67FE8C14E4845900DB7CC9 /* scrypt.1 */ = {isa = PBXFileReference; lastKnownFileType = text.man; path = scrypt.1; sourceTree = "<group>"; };
+		DA67FE8D14E4845900DB7CC9 /* scrypt_platform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = scrypt_platform.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A0511C55127770FD00DE46C4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA1A142614E4914E00BCFFBE /* libutil.a in Frameworks */,
+				DA1A140614E48A7600BCFFBE /* libcrypto.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D2AAC07C0554694100DB518D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA8251C514E5CDF7008EBC5A /* libscryptcrypto.a in Frameworks */,
+				DA1A142514E4914800BCFFBE /* libutil.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA67FE5914E4834300DB7CC9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		034768DFFF38A50411DB9C8B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D2AAC07E0554694100DB518D /* libscryptenc.a */,
+				A0511C5A127770FD00DE46C4 /* libscryptcrypto.a */,
+				DA67FE5D14E4834300DB7CC9 /* libutil.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0867D691FE84028FC02AAC07 /* openssl */ = {
+			isa = PBXGroup;
+			children = (
+				DA1A13E314E487D800BCFFBE /* openssl.xcodeproj */,
+				A05123771278ACDE00DE46C4 /* README */,
+				A0511321127769BB00DE46C4 /* Makefile */,
+				A051131E127769BB00DE46C4 /* build-aux */,
+				DA67FE6914E4845900DB7CC9 /* scrypt */,
+				0867D69AFE84028FC02AAC07 /* Frameworks */,
+				034768DFFF38A50411DB9C8B /* Products */,
+			);
+			name = openssl;
+			sourceTree = "<group>";
+		};
+		0867D69AFE84028FC02AAC07 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A0511E2B127789E000DE46C4 /* UIKit.framework */,
+				A0511E2D127789E900DE46C4 /* CoreGraphics.framework */,
+				AACBBE490F95108600F1A2B1 /* Foundation.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		A051131E127769BB00DE46C4 /* build-aux */ = {
+			isa = PBXGroup;
+			children = (
+				DA1A141614E48E9F00BCFFBE /* config.h */,
+				DA67FE6014E483BD00DB7CC9 /* configure-wrapper.log */,
+				DA67FE6114E483BD00DB7CC9 /* configure-wrapper.sh */,
+				DA67FE6214E483BD00DB7CC9 /* LICENSE */,
+				DA67FE6314E483BD00DB7CC9 /* scrypt-1.1.6.patch */,
+				DA67FE6414E483BD00DB7CC9 /* scrypt-1.1.6.tgz.md5 */,
+			);
+			path = "build-aux";
+			sourceTree = "<group>";
+		};
+		DA1A13E414E487D800BCFFBE /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				DA1A13F014E487D900BCFFBE /* libssl.a */,
+				DA1A13F214E487D900BCFFBE /* libcrypto.a */,
+				DA1A13F414E487D900BCFFBE /* test.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		DA67FE6914E4845900DB7CC9 /* scrypt */ = {
+			isa = PBXGroup;
+			children = (
+				DA1A140714E48E1600BCFFBE /* config.h */,
+				DA67FE6A14E4845900DB7CC9 /* config.aux */,
+				DA67FE6E14E4845900DB7CC9 /* config.h.in */,
+				DA67FE6F14E4845900DB7CC9 /* configure */,
+				DA67FE7014E4845900DB7CC9 /* FORMAT */,
+				DA67FE7114E4845900DB7CC9 /* lib */,
+				DA67FE8914E4845900DB7CC9 /* main.c */,
+				DA67FE8A14E4845900DB7CC9 /* Makefile.in */,
+				DA67FE8B14E4845900DB7CC9 /* patched_for_xcode */,
+				DA67FE8C14E4845900DB7CC9 /* scrypt.1 */,
+				DA67FE8D14E4845900DB7CC9 /* scrypt_platform.h */,
+			);
+			path = scrypt;
+			sourceTree = "<group>";
+		};
+		DA67FE6A14E4845900DB7CC9 /* config.aux */ = {
+			isa = PBXGroup;
+			children = (
+				DA67FE6B14E4845900DB7CC9 /* depcomp */,
+				DA67FE6C14E4845900DB7CC9 /* install-sh */,
+				DA67FE6D14E4845900DB7CC9 /* missing */,
+			);
+			path = config.aux;
+			sourceTree = "<group>";
+		};
+		DA67FE7114E4845900DB7CC9 /* lib */ = {
+			isa = PBXGroup;
+			children = (
+				DA67FE7214E4845900DB7CC9 /* crypto */,
+				DA67FE7B14E4845900DB7CC9 /* README */,
+				DA67FE7C14E4845900DB7CC9 /* scryptenc */,
+				DA67FE8114E4845900DB7CC9 /* util */,
+			);
+			path = lib;
+			sourceTree = "<group>";
+		};
+		DA67FE7214E4845900DB7CC9 /* crypto */ = {
+			isa = PBXGroup;
+			children = (
+				DA67FE7314E4845900DB7CC9 /* crypto_aesctr.c */,
+				DA67FE7414E4845900DB7CC9 /* crypto_aesctr.h */,
+				DA67FE7514E4845900DB7CC9 /* crypto_scrypt-nosse.c */,
+				DA67FE7614E4845900DB7CC9 /* crypto_scrypt-ref.c */,
+				DA67FE7814E4845900DB7CC9 /* crypto_scrypt.h */,
+				DA67FE7914E4845900DB7CC9 /* sha256.c */,
+				DA67FE7A14E4845900DB7CC9 /* sha256.h */,
+			);
+			path = crypto;
+			sourceTree = "<group>";
+		};
+		DA67FE7C14E4845900DB7CC9 /* scryptenc */ = {
+			isa = PBXGroup;
+			children = (
+				DA67FE7D14E4845900DB7CC9 /* scryptenc.c */,
+				DA67FE7E14E4845900DB7CC9 /* scryptenc.h */,
+				DA67FE7F14E4845900DB7CC9 /* scryptenc_cpuperf.c */,
+				DA67FE8014E4845900DB7CC9 /* scryptenc_cpuperf.h */,
+			);
+			path = scryptenc;
+			sourceTree = "<group>";
+		};
+		DA67FE8114E4845900DB7CC9 /* util */ = {
+			isa = PBXGroup;
+			children = (
+				DA67FE8214E4845900DB7CC9 /* memlimit.c */,
+				DA67FE8314E4845900DB7CC9 /* memlimit.h */,
+				DA67FE8414E4845900DB7CC9 /* readpass.c */,
+				DA67FE8514E4845900DB7CC9 /* readpass.h */,
+				DA67FE8614E4845900DB7CC9 /* sysendian.h */,
+				DA67FE8714E4845900DB7CC9 /* warn.c */,
+				DA67FE8814E4845900DB7CC9 /* warn.h */,
+			);
+			path = util;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		A0511C52127770FD00DE46C4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D2AAC07A0554694100DB518D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA67FE2B14E4834300DB7CC9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXLegacyTarget section */
+		A0511DED127788EC00DE46C4 /* Makefile-scrypt */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "$(ACTION)";
+			buildConfigurationList = A0511DF61277891C00DE46C4 /* Build configuration list for PBXLegacyTarget "Makefile-scrypt" */;
+			buildPhases = (
+			);
+			buildToolPath = /usr/bin/make;
+			dependencies = (
+			);
+			name = "Makefile-scrypt";
+			passBuildSettingsInEnvironment = 1;
+			productName = Makefile;
+		};
+/* End PBXLegacyTarget section */
+
+/* Begin PBXNativeTarget section */
+		A0511C51127770FD00DE46C4 /* scryptcrypto */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A0511C57127770FD00DE46C4 /* Build configuration list for PBXNativeTarget "scryptcrypto" */;
+			buildPhases = (
+				A0511C52127770FD00DE46C4 /* Headers */,
+				A0511C54127770FD00DE46C4 /* Sources */,
+				A0511C55127770FD00DE46C4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A0511DF3127788FD00DE46C4 /* PBXTargetDependency */,
+			);
+			name = scryptcrypto;
+			productName = openssl;
+			productReference = A0511C5A127770FD00DE46C4 /* libscryptcrypto.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		D2AAC07D0554694100DB518D /* scryptenc */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1DEB921E08733DC00010E9CD /* Build configuration list for PBXNativeTarget "scryptenc" */;
+			buildPhases = (
+				D2AAC07A0554694100DB518D /* Headers */,
+				D2AAC07B0554694100DB518D /* Sources */,
+				D2AAC07C0554694100DB518D /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A0511DF1127788F600DE46C4 /* PBXTargetDependency */,
+			);
+			name = scryptenc;
+			productName = openssl;
+			productReference = D2AAC07E0554694100DB518D /* libscryptenc.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		DA67FE2814E4834300DB7CC9 /* util */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA67FE5A14E4834300DB7CC9 /* Build configuration list for PBXNativeTarget "util" */;
+			buildPhases = (
+				DA67FE2B14E4834300DB7CC9 /* Headers */,
+				DA67FE2C14E4834300DB7CC9 /* Sources */,
+				DA67FE5914E4834300DB7CC9 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DA67FE2914E4834300DB7CC9 /* PBXTargetDependency */,
+			);
+			name = util;
+			productName = openssl;
+			productReference = DA67FE5D14E4834300DB7CC9 /* libutil.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0867D690FE84028FC02AAC07 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0420;
+			};
+			buildConfigurationList = 1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "scrypt" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
+			mainGroup = 0867D691FE84028FC02AAC07 /* openssl */;
+			productRefGroup = 034768DFFF38A50411DB9C8B /* Products */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = DA1A13E414E487D800BCFFBE /* Products */;
+					ProjectRef = DA1A13E314E487D800BCFFBE /* openssl.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				A0511DED127788EC00DE46C4 /* Makefile-scrypt */,
+				D2AAC07D0554694100DB518D /* scryptenc */,
+				A0511C51127770FD00DE46C4 /* scryptcrypto */,
+				DA67FE2814E4834300DB7CC9 /* util */,
+				A0511DCE127788A100DE46C4 /* scrypt */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		DA1A13F014E487D900BCFFBE /* libssl.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libssl.a;
+			remoteRef = DA1A13EF14E487D900BCFFBE /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DA1A13F214E487D900BCFFBE /* libcrypto.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libcrypto.a;
+			remoteRef = DA1A13F114E487D900BCFFBE /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DA1A13F414E487D900BCFFBE /* test.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = test.app;
+			remoteRef = DA1A13F314E487D900BCFFBE /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A0511C54127770FD00DE46C4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA67FE8E14E484A900DB7CC9 /* crypto_aesctr.c in Sources */,
+				DA67FE8F14E484B100DB7CC9 /* crypto_scrypt-nosse.c in Sources */,
+				DA67FE9014E484B100DB7CC9 /* crypto_scrypt-ref.c in Sources */,
+				DA67FE9214E484B100DB7CC9 /* sha256.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D2AAC07B0554694100DB518D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA67FE9314E484BB00DB7CC9 /* scryptenc.c in Sources */,
+				DA67FE9414E484BB00DB7CC9 /* scryptenc_cpuperf.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA67FE2C14E4834300DB7CC9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA67FE9514E484C200DB7CC9 /* memlimit.c in Sources */,
+				DA67FE9614E484C200DB7CC9 /* readpass.c in Sources */,
+				DA67FE9714E484C200DB7CC9 /* warn.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A0511DD2127788A800DE46C4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D2AAC07D0554694100DB518D /* scryptenc */;
+			targetProxy = A0511DD1127788A800DE46C4 /* PBXContainerItemProxy */;
+		};
+		A0511DD4127788A800DE46C4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A0511C51127770FD00DE46C4 /* scryptcrypto */;
+			targetProxy = A0511DD3127788A800DE46C4 /* PBXContainerItemProxy */;
+		};
+		A0511DF1127788F600DE46C4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A0511DED127788EC00DE46C4 /* Makefile-scrypt */;
+			targetProxy = A0511DF0127788F600DE46C4 /* PBXContainerItemProxy */;
+		};
+		A0511DF3127788FD00DE46C4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A0511DED127788EC00DE46C4 /* Makefile-scrypt */;
+			targetProxy = A0511DF2127788FD00DE46C4 /* PBXContainerItemProxy */;
+		};
+		DA67FE2914E4834300DB7CC9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A0511DED127788EC00DE46C4 /* Makefile-scrypt */;
+			targetProxy = DA67FE2A14E4834300DB7CC9 /* PBXContainerItemProxy */;
+		};
+		DA67FE5F14E4836300DB7CC9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA67FE2814E4834300DB7CC9 /* util */;
+			targetProxy = DA67FE5E14E4836300DB7CC9 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		1DEB921F08733DC00010E9CD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_MODEL_TUNING = G5;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		1DEB922008733DC00010E9CD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				GCC_MODEL_TUNING = G5;
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		1DEB922308733DC00010E9CD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = (
+					armv6,
+					armv7,
+				);
+				"ARCHS[sdk=iphonesimulator*]" = i386;
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../../include/**";
+				IPHONEOS_DEPLOYMENT_TARGET = 3.1;
+				OTHER_CFLAGS = "-DHAVE_CONFIG_H";
+				OTHER_LDFLAGS = "-ObjC";
+				SDKROOT = iphoneos;
+				VALID_ARCHS = "i386 armv6 armv7";
+			};
+			name = Debug;
+		};
+		1DEB922408733DC00010E9CD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = (
+					armv6,
+					armv7,
+				);
+				"ARCHS[sdk=iphonesimulator*]" = i386;
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../../include/**";
+				IPHONEOS_DEPLOYMENT_TARGET = 3.1;
+				OTHER_CFLAGS = "-DHAVE_CONFIG_H";
+				OTHER_LDFLAGS = "-ObjC";
+				SDKROOT = iphoneos;
+				VALID_ARCHS = "i386 armv6 armv7";
+			};
+			name = Release;
+		};
+		A0511C58127770FD00DE46C4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_MODEL_TUNING = G5;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		A0511C59127770FD00DE46C4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				GCC_MODEL_TUNING = G5;
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		A0511DCF127788A200DE46C4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				PRODUCT_NAME = scrypt;
+			};
+			name = Debug;
+		};
+		A0511DD0127788A200DE46C4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				PRODUCT_NAME = scrypt;
+				ZERO_LINK = NO;
+			};
+			name = Release;
+		};
+		A0511DEE127788ED00DE46C4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				PRODUCT_NAME = Makefile;
+			};
+			name = Debug;
+		};
+		A0511DEF127788ED00DE46C4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				PRODUCT_NAME = Makefile;
+				ZERO_LINK = NO;
+			};
+			name = Release;
+		};
+		DA67FE5B14E4834300DB7CC9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_MODEL_TUNING = G5;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
+				HEADER_SEARCH_PATHS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		DA67FE5C14E4834300DB7CC9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				GCC_MODEL_TUNING = G5;
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
+				HEADER_SEARCH_PATHS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1DEB921E08733DC00010E9CD /* Build configuration list for PBXNativeTarget "scryptenc" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1DEB921F08733DC00010E9CD /* Debug */,
+				1DEB922008733DC00010E9CD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "scrypt" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1DEB922308733DC00010E9CD /* Debug */,
+				1DEB922408733DC00010E9CD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A0511C57127770FD00DE46C4 /* Build configuration list for PBXNativeTarget "scryptcrypto" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A0511C58127770FD00DE46C4 /* Debug */,
+				A0511C59127770FD00DE46C4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A0511DEA127788C900DE46C4 /* Build configuration list for PBXAggregateTarget "scrypt" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A0511DCF127788A200DE46C4 /* Debug */,
+				A0511DD0127788A200DE46C4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A0511DF61277891C00DE46C4 /* Build configuration list for PBXLegacyTarget "Makefile-scrypt" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A0511DEE127788ED00DE46C4 /* Debug */,
+				A0511DEF127788ED00DE46C4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DA67FE5A14E4834300DB7CC9 /* Build configuration list for PBXNativeTarget "util" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA67FE5B14E4834300DB7CC9 /* Debug */,
+				DA67FE5C14E4834300DB7CC9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0867D690FE84028FC02AAC07 /* Project object */;
+}

--- a/ports/security/scrypt/scrypt.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ports/security/scrypt/scrypt.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:scrypt.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
openssl: Apply Xcode's "modernization" + add armv6 to arch list so it keeps working on iPhone & iPhone 3G in later versions of Xcode.
